### PR TITLE
Fix: Remove preset schema migration for id field

### DIFF
--- a/src/api/services/SchemaMigrationService.js
+++ b/src/api/services/SchemaMigrationService.js
@@ -26,9 +26,6 @@ module.exports = class SchemaMigrationService extends Service {
       this.app.log
         .debug(`SchemaMigrationService: performing "create" migration for model ${tableName}`);
       return txn.schema.createTableIfNotExists(model.getTableName(), table => {
-        let { idAttribute } = config;
-        idAttribute = idAttribute || 'id';
-        table.increments(idAttribute).primary();
         if (config.hasTimestamps || (isUndefined(config.hasTimestamps) && hasTimestamps)) {
           if (isArray(hasTimestamps)) {
             table.timestamp(hasTimestamps[0]).defaultTo(table.client.raw('CURRENT_TIMESTAMP'));

--- a/test/config.js
+++ b/test/config.js
@@ -15,6 +15,7 @@ module.exports = defaultsDeep({
         }
         static schema (table) {
           if (table) {
+            table.increments('id').primary();
             table.string('name').notNullable().unique();
             return table;
           } else {
@@ -40,6 +41,7 @@ module.exports = defaultsDeep({
         }
         static schema(table) {
           if (table) {
+            table.increments('id').primary();
             table.integer('user_id').notNullable().references('id').inTable('user');
             table.integer('role_id').notNullable().references('id').inTable('role');
             return table;
@@ -61,6 +63,7 @@ module.exports = defaultsDeep({
         }
         static schema(table) {
           if (table) {
+            table.increments('id').primary();
             table.string('name').notNullable().unique();
             return table;
           } else {
@@ -78,6 +81,7 @@ module.exports = defaultsDeep({
         }
         static schema(table) {
           if (table) {
+            table.increments('id').primary();
             table.string('first_name');
             table.string('last_name');
             table.integer('user_id').notNullable().references('id').inTable('user');
@@ -97,6 +101,7 @@ module.exports = defaultsDeep({
         }
         static schema(table) {
           if (table) {
+            table.increments('id').primary();
             table.string('title').notNullable();
             table.string('text').notNullable();
             table.integer('user_id').notNullable().references('id').inTable('user');


### PR DESCRIPTION
Currently the SchemaMigrationService assumes the id field will always be of type incremental. This makes it impossible to use another type for id fields (like UUID) as knex throws an error when trying to set the id field again in an individual model's schema. It could be possible to have some config for the field type but since the main goal for this package is to wrap bookshelf I think we should remove this and maintain the flexibility to set it manually in the model schema.

Fixes #11 