### PR TITLE
Care about plugins config variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const findBsStores = stores => reduce(stores, (res, store, storeName) =>
   Object.assign(
     res,
     store.orm === BOOKSHELF ?
-    { [storeName]: pick(store, 'client', 'connection', 'useNullAsDefault') } :
+    { [storeName]: pick(store, 'client', 'connection', 'useNullAsDefault', 'plugins') } :
     {}
   ), {});
 


### PR DESCRIPTION
We try to get `plugins` in `initialize` method, but it is possible possible until we get it from `store` object.

Todo:

* [ ] Documentation
* [ ] Check work of non-official plugins
* [ ] Tests